### PR TITLE
Encode runner output

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,6 +22,7 @@ class Project(object):
         self.git.init()
         self.git.config('user.name', 'test-suite')
         self.git.config('user.email', 'test-suite@therapist.xyz')
+        self.git.config('commit.gpgsign', 'false')
 
         # Commit all files to the repo
         self.git.add('.')

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,6 +1,8 @@
 import pytest
 import re
 
+import six
+
 from therapist import Runner
 
 from . import Project
@@ -312,3 +314,21 @@ class TestRunner(object):
         out, err = capsys.readouterr()
 
         assert re.search('Linting(.+?)\[SUCCESS]', out)
+
+    def test_output_encoded(self, tmpdir, capsys):
+        p = Project(tmpdir.strpath)
+
+        p.write('fail.txt')
+        p.git.add('.')
+
+        r = Runner(p.config_file)
+        with pytest.raises(r.ActionFailed):
+            r.run()
+
+        assert 'fail.txt' in r.files
+
+        out, err = capsys.readouterr()
+
+        assert isinstance(out, six.text_type)
+        assert 'b"' not in out
+        assert "b'" not in out

--- a/therapist/runner.py
+++ b/therapist/runner.py
@@ -37,9 +37,9 @@ def execute_action(action, files, cwd):
         std_out, std_err = pipes.communicate()
 
         if len(std_err):
-            return std_err, Runner.FAILURE
+            return std_err.decode(), Runner.FAILURE
         else:
-            return std_out, Runner.SUCCESS if pipes.returncode == 0 else Runner.FAILURE
+            return std_out.decode(), Runner.SUCCESS if pipes.returncode == 0 else Runner.FAILURE
 
     return None, Runner.SKIPPED
 


### PR DESCRIPTION
This regressed since last time, so I added a test. Hopefully this works in both Python 2 and 3. 

I also added a `git config` to the test project to not sign things. If git is configured globally to sign all commits, not doing this causes the tests to constantly ask for gpg signing, which is really annoying (and slow). It might be good to figure out if we can ask git to ignore the global config instead.

r?