### PR TITLE
Delete files should not be passed to actions when the `use-tracked-files` flag is passed

### DIFF
--- a/tests/sample_project/scripts/lint.py
+++ b/tests/sample_project/scripts/lint.py
@@ -7,6 +7,8 @@ BASE_DIR = os.path.abspath(os.curdir)
 
 
 def check(f):
+    if not os.path.exists(f):
+        exit(1)
     with open(f, "r") as fp:
         if "fail" in f or fp.read().upper() == "FAIL":
             print("FAIL!  {}".format(f))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -643,6 +643,16 @@ class TestRun(object):
             assert result.exception
             assert result.exit_code == 1
 
+    def test_deleted_files_skipped_when_using_tracked_files(self, cli_runner, project):
+        with chdir(project.path):
+            project.write("test.txt", "testing")
+            project.git.add(".")
+            project.git.commit(m="Add file")
+            project.remove("test.txt")
+
+            result = cli_runner.invoke(cli.run, ["--include-unstaged", "--include-untracked", "--use-tracked-files"])
+            assert result.exit_code == 0
+
 
 class TestUse(object):
     def test_outside_repo(self, cli_runner, tmpdir):

--- a/therapist/cli.py
+++ b/therapist/cli.py
@@ -300,6 +300,12 @@ def run(**kwargs):
         out, err, code = git.ls_files()
         files = out.splitlines()
 
+        # Filter out any files that have been deleted
+        out, err, code = git.status(porcelain=True)
+        for line in out.splitlines():
+            if line[0] == "D" or line[1] == "D":
+                files.remove(line[3:])
+
         if kwargs.get("include_untracked"):
             out, err, code = git.ls_files(o=True, exclude_standard=True)
             files += out.splitlines()


### PR DESCRIPTION
Fixes #124 